### PR TITLE
Just some xml doc clarifications

### DIFF
--- a/CommonIO/CommonIO.csproj
+++ b/CommonIO/CommonIO.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\CommonIO.XML</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +29,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\CommonIO.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Patterns.Logging">
@@ -56,7 +58,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>if $(ConfigurationName) == Release (
-xcopy "$(TargetPath)" "$(SolutionDir)\nuget\dlls\" /y /d /r /i
+xcopy "$(TargetDir)." "$(SolutionDir)\nuget\dlls\" /y /d /r /i
 )</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/CommonIO/IFileSystem.cs
+++ b/CommonIO/IFileSystem.cs
@@ -32,24 +32,32 @@ namespace CommonIO
         void CreateShortcut(string shortcutPath, string target);
 
         /// <summary>
-        /// Gets the file system info.
+        /// Returns a <see cref="FileSystemMetadata"/> object for the specified file or directory path.
         /// </summary>
-        /// <param name="path">The path.</param>
-        /// <returns>FileSystemInfo.</returns>
+        /// <param name="path">A path to a file or directory.</param>
+        /// <returns>A <see cref="FileSystemMetadata"/> object.</returns>
+        /// <remarks>If the specified path points to a directory, the returned <see cref="FileSystemMetadata"/> object's
+        /// <see cref="FileSystemMetadata.IsDirectory"/> property will be set to true and all other properties will reflect the properties of the directory.</remarks>
         FileSystemMetadata GetFileSystemInfo(string path);
 
         /// <summary>
-        /// Gets the file information.
+        /// Returns a <see cref="FileSystemMetadata"/> object for the specified file path.
         /// </summary>
-        /// <param name="path">The path.</param>
-        /// <returns>FileSystemMetadata.</returns>
+        /// <param name="path">A path to a file.</param>
+        /// <returns>A <see cref="FileSystemMetadata"/> object.</returns>
+        /// <remarks><para>If the specified path points to a directory, the returned <see cref="FileSystemMetadata"/> object's
+        /// <see cref="FileSystemMetadata.IsDirectory"/> property and the <see cref="FileSystemMetadata.Exists"/> property will both be set to false.</para>
+        /// <para>For automatic handling of files <b>and</b> directories, use <see cref="GetFileSystemInfo"/>.</para></remarks>
         FileSystemMetadata GetFileInfo(string path);
 
         /// <summary>
-        /// Gets the directory information.
+        /// Returns a <see cref="FileSystemMetadata"/> object for the specified directory path.
         /// </summary>
-        /// <param name="path">The path.</param>
-        /// <returns>FileSystemMetadata.</returns>
+        /// <param name="path">A path to a directory.</param>
+        /// <returns>A <see cref="FileSystemMetadata"/> object.</returns>
+        /// <remarks><para>If the specified path points to a file, the returned <see cref="FileSystemMetadata"/> object's
+        /// <see cref="FileSystemMetadata.IsDirectory"/> property will be set to true and the <see cref="FileSystemMetadata.Exists"/> property will be set to false.</para>
+        /// <para>For automatic handling of files <b>and</b> directories, use <see cref="GetFileSystemInfo"/>.</para></remarks>
         FileSystemMetadata GetDirectoryInfo(string path);
 
         /// <summary>

--- a/CommonIO/ManagedFileSystem.cs
+++ b/CommonIO/ManagedFileSystem.cs
@@ -124,10 +124,12 @@ namespace CommonIO
         }
 
         /// <summary>
-        /// Gets the file system info.
+        /// Returns a <see cref="FileSystemMetadata"/> object for the specified file or directory path.
         /// </summary>
-        /// <param name="path">The path.</param>
-        /// <returns>FileSystemInfo.</returns>
+        /// <param name="path">A path to a file or directory.</param>
+        /// <returns>A <see cref="FileSystemMetadata"/> object.</returns>
+        /// <remarks>If the specified path points to a directory, the returned <see cref="FileSystemMetadata"/> object's
+        /// <see cref="FileSystemMetadata.IsDirectory"/> property will be set to true and all other properties will reflect the properties of the directory.</remarks>
         public FileSystemMetadata GetFileSystemInfo(string path)
         {
             if (string.IsNullOrEmpty(path))
@@ -160,6 +162,14 @@ namespace CommonIO
             }
         }
 
+        /// <summary>
+        /// Returns a <see cref="FileSystemMetadata"/> object for the specified file path.
+        /// </summary>
+        /// <param name="path">A path to a file.</param>
+        /// <returns>A <see cref="FileSystemMetadata"/> object.</returns>
+        /// <remarks><para>If the specified path points to a directory, the returned <see cref="FileSystemMetadata"/> object's
+        /// <see cref="FileSystemMetadata.IsDirectory"/> property and the <see cref="FileSystemMetadata.Exists"/> property will both be set to false.</para>
+        /// <para>For automatic handling of files <b>and</b> directories, use <see cref="GetFileSystemInfo"/>.</para></remarks>
         public FileSystemMetadata GetFileInfo(string path)
         {
             if (string.IsNullOrEmpty(path))
@@ -172,6 +182,14 @@ namespace CommonIO
             return GetFileSystemMetadata(fileInfo);
         }
 
+        /// <summary>
+        /// Returns a <see cref="FileSystemMetadata"/> object for the specified directory path.
+        /// </summary>
+        /// <param name="path">A path to a directory.</param>
+        /// <returns>A <see cref="FileSystemMetadata"/> object.</returns>
+        /// <remarks><para>If the specified path points to a file, the returned <see cref="FileSystemMetadata"/> object's
+        /// <see cref="FileSystemMetadata.IsDirectory"/> property will be set to true and the <see cref="FileSystemMetadata.Exists"/> property will be set to false.</para>
+        /// <para>For automatic handling of files <b>and</b> directories, use <see cref="GetFileSystemInfo"/>.</para></remarks>
         public FileSystemMetadata GetDirectoryInfo(string path)
         {
             if (string.IsNullOrEmpty(path))

--- a/nuget/CommonIO.nuspec
+++ b/nuget/CommonIO.nuspec
@@ -17,5 +17,6 @@
     </metadata>
     <files>
         <file src="dlls\CommonIO.dll" target="lib\net45\CommonIO.dll" />
+        <file src="dlls\CommonIO.xml" target="lib\net45\CommonIO.xml" />
     </files>
 </package>


### PR DESCRIPTION
Calling GetFileInfo("c:\windows") returns a FileSystemMetadata object
where .IsDirectory == false.
This is a bit misleading, but actually it's just the same behaviour as
provided by the .NET framework.
The GetFileSystemInfo method does that selectively, but its naming
suggests a very different purpose (like returning information about the
actual *file system* - FAT, NTFS, EXTX).

At least here are some improvements to the xml docs.